### PR TITLE
Fixed Github link in docs

### DIFF
--- a/docs/_build/html/_modules/domonic/CDN.html
+++ b/docs/_build/html/_modules/domonic/CDN.html
@@ -221,7 +221,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/JSON.html
+++ b/docs/_build/html/_modules/domonic/JSON.html
@@ -316,7 +316,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/dQuery.html
+++ b/docs/_build/html/_modules/domonic/dQuery.html
@@ -1811,7 +1811,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/decorators.html
+++ b/docs/_build/html/_modules/domonic/decorators.html
@@ -220,7 +220,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/dom.html
+++ b/docs/_build/html/_modules/domonic/dom.html
@@ -1619,7 +1619,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/events.html
+++ b/docs/_build/html/_modules/domonic/events.html
@@ -1051,7 +1051,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/html.html
+++ b/docs/_build/html/_modules/domonic/html.html
@@ -586,7 +586,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/javascript.html
+++ b/docs/_build/html/_modules/domonic/javascript.html
@@ -1658,7 +1658,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/lerpy/tween.html
+++ b/docs/_build/html/_modules/domonic/lerpy/tween.html
@@ -340,7 +340,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/style.html
+++ b/docs/_build/html/_modules/domonic/style.html
@@ -2586,7 +2586,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/svg.html
+++ b/docs/_build/html/_modules/domonic/svg.html
@@ -252,7 +252,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/terminal.html
+++ b/docs/_build/html/_modules/domonic/terminal.html
@@ -538,7 +538,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/utils.html
+++ b/docs/_build/html/_modules/domonic/utils.html
@@ -307,7 +307,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/domonic/x3d.html
+++ b/docs/_build/html/_modules/domonic/x3d.html
@@ -375,7 +375,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/_modules/index.html
+++ b/docs/_build/html/_modules/index.html
@@ -122,7 +122,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/genindex.html
+++ b/docs/_build/html/genindex.html
@@ -3403,7 +3403,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/index.html
+++ b/docs/_build/html/index.html
@@ -294,7 +294,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/CDN.html
+++ b/docs/_build/html/packages/CDN.html
@@ -345,7 +345,7 @@ img(_src=CDN_IMG.PLACEHOLDER(300,100,’x’))</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/JSON.html
+++ b/docs/_build/html/packages/JSON.html
@@ -222,7 +222,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/Tween.html
+++ b/docs/_build/html/packages/Tween.html
@@ -211,7 +211,7 @@ Just pass an easing equation from the easing package</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/autodocs.html
+++ b/docs/_build/html/packages/autodocs.html
@@ -8287,7 +8287,7 @@ Just pass an easing equation from the easing package</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/components.html
+++ b/docs/_build/html/packages/components.html
@@ -336,7 +336,7 @@ app/components/my_component.py</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/constants.html
+++ b/docs/_build/html/packages/constants.html
@@ -117,7 +117,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/dQuery.html
+++ b/docs/_build/html/packages/dQuery.html
@@ -1257,7 +1257,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/dom.html
+++ b/docs/_build/html/packages/dom.html
@@ -1215,7 +1215,7 @@ or the current position of the caret.</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/html.html
+++ b/docs/_build/html/packages/html.html
@@ -966,7 +966,7 @@ i.e. hypenated tags &lt;some-custom-tag&gt;&lt;/some-custom-tag&gt;</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/javascript.html
+++ b/docs/_build/html/packages/javascript.html
@@ -994,7 +994,7 @@ and through the specified number of character</p>
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/terminal.html
+++ b/docs/_build/html/packages/terminal.html
@@ -1329,7 +1329,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/packages/x3d.html
+++ b/docs/_build/html/packages/x3d.html
@@ -2878,7 +2878,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/py-modindex.html
+++ b/docs/_build/html/py-modindex.html
@@ -198,7 +198,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     

--- a/docs/_build/html/search.html
+++ b/docs/_build/html/search.html
@@ -122,7 +122,7 @@
     </div>
 
     
-    <a href="https://github.com/requests/requests" class="github">
+    <a href="https://github.com/byteface/domonic" class="github">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
     </a>
     


### PR DESCRIPTION
The link to the GitHub repo in the docs was wrong. it is fixed now.