### PR TITLE
Add slots for tag class

### DIFF
--- a/domonic/html.py
+++ b/domonic/html.py
@@ -86,7 +86,12 @@ class tag(object):
     The class from which all html tags extend.
     """
 
-    # TODO - slots?.
+    __slots__ = [
+        "args",
+        "kwargs",
+        "__content",
+        "__attributes",
+    ]
 
     def __init__(self, *args, **kwargs):
         self.args = args


### PR DESCRIPTION
It looks like issue #21 mentions that you wanted to use `__slots__` in this project. I'm not familiar with the structure of the project or where all the classes are defined, so this PR only adds `__slots__` for the one class that had the todo comment for it.

All of the rest of the classes should be just as simple. You just have to list out all of the expected instance attributes for each class. If a class is simple and just assigns all of it's attributes normally with `self.<name> = ...` in it's `__init__` or elsewhere, then you can just search for `self.\w+ = ` to locate names easily.

Using `__slots__` instead of the default `__dict__` for attributes is pretty straightforward unless you have classes where instance attributes are dynamically set (not just appear to be set with a `__getattr__` or `__getattribute__` that intercepts attribute access).

I'm not sure this change warrants any extra tests since the existing test suite covers all of the attribute assignments in the `tag` class

```
$ coverage run -m unittest discover tests
<lots of output, enough lines with just hi to fill up my entire terminal history>
...
----------------------------------------------------------------------
Ran 259 tests in 19.748s

OK
$ coverage report -m | grep html
Name                                                                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------
domonic/html.py                                                                       294     45    85%   65-66, 72-78, 103-104, 121-122, 130-131, 155-158, 169-172, 178-181, 187-190, 194-196, 225-227, 265, 272, 322, 487, 490, 493, 512, 515
tests/test_html.py                                                                     77     25    68%   47-56, 60-91, 95-133, 137-358, 362-532, 537-805, 845
```