### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -1009,7 +1009,7 @@ class TestCase(unittest.TestCase):
         # this may have been due to that
         # TODO - mulitple arguments to comment
 
-    def test_body(self):
+    def test_body_two(self):
         print('im running1')
         aNewBodyElement = document.createElement("body")
         aNewBodyElement.id = "newBodyElement"


### PR DESCRIPTION
Fixes #57.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

