### PR TITLE
build: upgrade requests and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 elementpath~=2.5.2
 python-dateutil==2.8.2
-requests~=2.28.0
-urllib3~=1.26.9
+requests~=2.31.0
+urllib3~=2.0.5
 html5lib~=1.1
 cssselect~=1.1.0


### PR DESCRIPTION
closes #63 

I tried running the tests locally with `python3 -m pytest tests` (`pytest tests` did not work directly in my venv for some reasons).
I got the following errors, which seem unrelated to the dependency upgrade here?
```
FAILED tests/test_javascript_date.py::TestCase::test_getTime - assert 787021200000 == 787017600000
FAILED tests/test_javascript_date.py::TestCase::test_javascript_date - assert 1 == 0
FAILED tests/test_webapi.py::TestCase::test_xpath - requests.exceptions.ConnectTimeout: HTTPConnectionPool(host='eventual.technology', port=80): Max retries exceeded with url: / (Caused by Co...
================================================== 3 failed, 506 passed in 548.60s (0:09:08) ===================================================
```
