### PR TITLE
Javascript Date: Fix Timezone Usage in Unit Tests

### DIFF
--- a/domonic/javascript.py
+++ b/domonic/javascript.py
@@ -1611,7 +1611,7 @@ class Date(Object):
             self.setMilliseconds(msValue)
         return self.getTime()
 
-    def setTime(self, milliseconds: int = None):
+    def setTime(self, milliseconds: int = None, tz: Any = None):
         """Sets the date and time of a date object
 
         Args:
@@ -1621,9 +1621,9 @@ class Date(Object):
             _type_: _description_
         """
         if milliseconds is None:
-            self.date = datetime.datetime.now()
+            self.date = datetime.datetime.now(tz)
         else:
-            self.date = datetime.datetime.fromtimestamp(milliseconds / 1000)
+            self.date = datetime.datetime.fromtimestamp(milliseconds / 1000, tz)
         return milliseconds
 
     def setUTCDate(self, day):

--- a/tests/test_javascript_date.py
+++ b/tests/test_javascript_date.py
@@ -26,7 +26,7 @@ class TestCase(unittest.TestCase):
 
         d = Date()
         # set the date
-        d.setTime(1546300800000)  # 2019-01-01, was on a Tuesday
+        d.setTime(1546300800000, timezone.utc)  # 2019-01-01, was on a Tuesday
         # print('>>', d.getDate())
         assert d.getDate() == 1
 
@@ -174,7 +174,7 @@ class TestCase(unittest.TestCase):
         # // Since month is zero based, birthday will be January 10, 1995
         birthday = Date(1994, 12, 10)
         acopy = Date()
-        acopy.setTime(birthday.getTime())
+        acopy.setTime(birthday.getTime(), timezone.utc)
         assert acopy.getTime() == birthday.getTime()
 
     # def test_getTimezoneOffset(self):


### PR DESCRIPTION
Helllo 👋 First-time open source contributor here, so open to feedback!

I wanted to submit a fix for the failing Javascript package's Date unit tests. The timestamp usage assumes GMT timezone, so I think we can be a bit more explicit with providing an optional timezone in `setTime`.

Verification steps:
```
python3 -m pytest tests/test_javascript_date.py
```

---

P.s. thanks for keeping this project up, it's helped me a lot with prototyping and quick visual validation at work!