### PR TITLE
Remove annoying warning

### DIFF
--- a/domonic/dom.py
+++ b/domonic/dom.py
@@ -2208,7 +2208,7 @@ class Element(Node):
                 context = []
                 for fnd in found:
                     if fnd.getAttribute("class") and re.search(
-                        r"(^|\s)" + class_name + "(\s|$)", fnd.getAttribute("class")
+                        r"(^|\s)" + class_name + r"(\s|$)", fnd.getAttribute("class")
                     ):
                         context.append(fnd)
 


### PR DESCRIPTION
### **User description**
When use domonic, first import emits warning with new python version.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix regex pattern to use raw string literal

- Resolve Python deprecation warning for invalid escape sequence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Regex pattern with escape sequence"] --> B["Raw string literal"] 
  B --> C["Warning resolved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dom.py</strong><dd><code>Fix regex escape sequence warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domonic/dom.py

<ul><li>Convert regex pattern string to raw string literal<br> <li> Fix invalid escape sequence warning in class name matching</ul>


</details>


  </td>
  <td><a href="https://github.com/byteface/domonic/pull/77/files#diff-3ae562e75d9db4cfa16ed6781d1ff2d7e5c55daf70012c63ab0e2bde0377238e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

